### PR TITLE
Make the name be optional

### DIFF
--- a/.babel-plugin/test/test.js
+++ b/.babel-plugin/test/test.js
@@ -41,6 +41,44 @@ export default createMethod({
       `;
       assert.equal(transform(code, '/methods/index.js', 'os.osx.x86_64'), code.trim());
     });
+    it('should add missing names on the server', () => {
+        const code = `
+import { createMethod } from 'meteor/zodern:relay';
+export const createProject = createMethod({
+});
+export default createMethod({
+  
+});
+      `;
+        const expected = `
+import { createMethod } from 'meteor/zodern:relay';
+export const createProject = createMethod({
+  name: "createProjectM000bd"
+});
+export default createMethod({
+  name: "projectsM000bd"
+});
+      `;
+        assert.equal(transform(code, '/methods/projects.js', 'os.osx.x86_64'), expected.trim());
+    });
+
+    it('should add missing names on the client', () => {
+      const code = `
+import { createMethod } from 'meteor/zodern:relay';
+export const createProject = createMethod({
+});
+export default createMethod({
+  
+});
+      `;
+      const expected = `
+import { _createClientMethod } from "meteor/zodern:relay/client";
+export const createProject = _createClientMethod("createProjectM000bd");
+export default _createClientMethod("projectsM000bd");
+      `;
+      assert.equal(transform(code, '/methods/projects.js'), expected.trim());
+    });
+
     it('should handle default exports', () => {
       const code = `
         import { createMethod } from 'meteor/zodern:relay';
@@ -129,7 +167,23 @@ import { _createClientPublication } from "meteor/zodern:relay/client";
 export const sub1 = _createClientPublication("pub1");
 export default _createClientPublication("pub2");
       `.trim());
-    })
+    });
+
+    it('should add missing names', () => {
+      const code = `
+        import { createPublication } from 'meteor/zodern:relay';
+        export const subscribeProjects = createPublication({ })
+          .pipeline(() => []);
+
+        export default createPublication({ });
+      `
+
+      assert.equal(transform(code, '/publications/index.js'), `
+import { _createClientPublication } from "meteor/zodern:relay/client";
+export const subscribeProjects = _createClientPublication("projectsM2962a");
+export default _createClientPublication("indexM2962a");
+      `.trim());
+    });
   });
 
   describe('wrongFolder', () => {

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ export const add = createMethod({
 
 The schema is used to provide types for for the `run` function's parameter, and to check the arguments when calling the method.
 
-The `name` is optional. If it is not provided, the babel plugin will add one based on the export name and file name. For example, if a method exported as `createProject` did not have a name, the generated name might look like `createProjectM2962a`.
+The `name` is optional. If it is not provided, the babel plugin will add one based on the export name and file name.
 
 `createMethod` returns a function you can use to call the method. The function returns a promise that resolves with the result. The result will have the same type as the return value of the `run` function.
 
@@ -149,7 +149,7 @@ export const subscribeProject = createPublication({
 
 The schema is used to provide types for for the `run` function's parameter, and to check the arguments when subscribing to the publication.
 
-The `name` is optional. If it is not provided, the babel plugin will add one based on the export name and file name, with the `subscribe` prefix removed. If the above example did not have a name, the generated name might look like `projectM2957c`.
+The `name` is optional. If it is not provided, the babel plugin will add one based on the export name and file name.
 
 `createPublication` returns a function you can use to subscribe to the publication. This function returns a [Subscription Handle](https://docs.meteor.com/api/pubsub.html#Meteor-subscribe), the same as `Meteor.subscribe` would.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ import { z } from 'zod';
 import { Projects } from '/shared/collections';
 
 export const createProject = createMethod({
-  name: 'projects.create',
   schema: z.object({
     name: z.string(),
     description: z.string().optional(),
@@ -99,6 +98,8 @@ export const add = createMethod({
 
 The schema is used to provide types for for the `run` function's parameter, and to check the arguments when calling the method.
 
+The `name` is optional. If it is not provided, the babel plugin will add one based on the export name and file name. For example, if a method exported as `createProject` did not have a name, the generated name might look like `createProjectM2962a`.
+
 `createMethod` returns a function you can use to call the method. The function returns a promise that resolves with the result. The result will have the same type as the return value of the `run` function.
 
 ```ts
@@ -147,6 +148,8 @@ export const subscribeProject = createPublication({
 `schema` is always required, and must be a schema created from the `zod` npm package. If the method does not have any arguments, you can use `zod.undefined()` as the schema. If you do not want to check the arguments, you can use `zod.any()`.
 
 The schema is used to provide types for for the `run` function's parameter, and to check the arguments when subscribing to the publication.
+
+The `name` is optional. If it is not provided, the babel plugin will add one based on the export name and file name, with the `subscribe` prefix removed. If the above example did not have a name, the generated name might look like `projectM2957c`.
 
 `createPublication` returns a function you can use to subscribe to the publication. This function returns a [Subscription Handle](https://docs.meteor.com/api/pubsub.html#Meteor-subscribe), the same as `Meteor.subscribe` would.
 

--- a/tests/method-tests.js
+++ b/tests/method-tests.js
@@ -14,7 +14,8 @@ const {
   contextMethod,
   getEvents,
   contextFailedMethod,
-  globalPipelineMethod
+  globalPipelineMethod,
+  unnamedMethod
 } = require('./methods/index.js');
 
 Tinytest.addAsync('methods - basic', async (test) => {
@@ -128,4 +129,9 @@ Tinytest.addAsync('methods - context error', async (test) => {
 Tinytest.addAsync('methods - global pipeline', async (test) => {
     const result = await globalPipelineMethod(5);
     test.equal(result, 6);
+});
+
+Tinytest.addAsync('methods - unnamed method', async (test) => {
+  const result = await unnamedMethod(10);
+  test.equal(result, 5);
 });

--- a/tests/methods/index.js
+++ b/tests/methods/index.js
@@ -159,6 +159,13 @@ export const globalPipelineMethod = createMethod({
   }
 });
 
+export const unnamedMethod = createMethod({
+  schema: z.number(),
+  run(input) {
+    return input / 2;
+  }
+});
+
 // Used for publication tests
 
 export const Numbers = new Mongo.Collection('numbers');

--- a/tests/publication-tests.js
+++ b/tests/publication-tests.js
@@ -1,7 +1,7 @@
 import {
   globalPipelinePub,
   reactiveSubscribe,
-  subscribeBasic, subscribeContext, subscribeError, subscribeFailedContext, subscribeFast, subscribePartial, subscribePipeline, subscribeRateLimited, subscribeReactivePipeline, subscribeSlow
+  subscribeBasic, subscribeContext, subscribeError, subscribeFailedContext, subscribeFast, subscribePartial, subscribePipeline, subscribeRateLimited, subscribeSlow, unnamedSubscribe
 } from './publications/index';
 import {
   createPublication
@@ -144,10 +144,19 @@ Tinytest.addAsync('publications - global pipeline', (test, done) => {
     10,
     {
       async onReady() {
-        console.log('ready');
         sub.stop();
         let events = await getEvents();
         test.equal(events, ['input: 11']);
+        done();
+      }
+    });
+});
+
+Tinytest.addAsync('publications - unnamed', (test, done) => {
+  let sub = unnamedSubscribe(
+    {
+      async onReady() {
+        sub.stop();
         done();
       }
     });

--- a/tests/publications/index.js
+++ b/tests/publications/index.js
@@ -177,4 +177,11 @@ export const reactiveSubscribe = createPublication({
       num: { $in: selected.map(s => s.num )}
     });
   }
-)
+);
+
+export const unnamedSubscribe = createPublication({
+  schema: z.undefined(),
+  run() {
+    return []
+  }
+});


### PR DESCRIPTION
You no longer have to provide a name when creating a method or publication. The babel plugin will add one if it is missing, using the export name and a short hash of the file name to generate it.