### PR TITLE
Fix error when using `export class`

### DIFF
--- a/.babel-plugin/plugin.js
+++ b/.babel-plugin/plugin.js
@@ -372,6 +372,10 @@ module.exports = function (api) {
           return;
         }
 
+        if (declaration.type == 'ClassDeclaration') {
+          return;
+        }
+
         if (declaration.type !== 'VariableDeclaration') {
           throw new Error(`export declarations of type ${declaration.type} are not supported`);
         }


### PR DESCRIPTION
Fixes "export declarations of type ClassDeclaration are not supported" when using code like this:

```js
export class Foo {
  // ...
}
```